### PR TITLE
Set the X keyboard layout in a file parsable by localectl

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -181,9 +181,6 @@ postinstall(){
 	# Configure touchpad
 	set_synaptics
 
-	# Set keyboard layout
-	sed -i "s#Identifier \"evdev keyboard catchall\".*#&\n        Option \"XkbLayout\" \"${LANG_CODE}\"#" ${DESTDIR}/etc/X11/xorg.conf.d/10-evdev.conf
-
 	# Set Antergos name in filesystem files
 	cp /etc/arch-release ${DESTDIR}/etc
 	cp -f /etc/os-release ${DESTDIR}/etc/os-release

--- a/src/installation_thread.py
+++ b/src/installation_thread.py
@@ -770,6 +770,17 @@ class InstallationThread(threading.Thread):
         with open(vconsole_conf_path, "wt") as vconsole_conf:
             vconsole_conf.write('KEYMAP=%s \n' % lang_code)
 
+        # Set /etc/X11/xorg.conf.d/00-keyboard.conf for the xkblayout
+        xorg_conf_xkb_path = os.path.join(self.dest_dir, "etc/X11/xorg.conf.d/00-keyboard.conf")
+        with open(xorg_conf_xkb_path, "wt") as xorg_conf_xkb:
+           xorg_conf_xkb.write("# Read and parsed by systemd-localed. It's probably wise not to edit this file\n")
+           xorg_conf_xkb.write('# manually too freely.\n')
+           xorg_conf_xkb.write('Section "InputClass"\n')
+           xorg_conf_xkb.write('        Identifier "system-keyboard"\n')
+           xorg_conf_xkb.write('        MatchIsKeyboard "on"\n')
+           xorg_conf_xkb.write('        Option "XkbLayout" "%s"\n' % lang_code)
+           xorg_conf_xkb.write('EndSection\n')
+
         self.auto_timesetting()
 
         # Set autologin if selected


### PR DESCRIPTION
The current Cnchi code runs `sed` in the post install script to set the xkblayout in /etc/X11/xorg.conf.d/10-evdev.conf. In systemd-based systems, this should be set in /etc/X11/xorg.conf.d/00-keyboard.conf, which is where the `localectl` expects the xkblayout settings to be.

This pull request changes Cnchi so that it writes /etc/X11/xorg.conf.d/00-keyboard.conf in a format understandable by the systemd `localectl` tool.
