### PR TITLE
Add support for enabling autologin with LightDM

### DIFF
--- a/src/installation_thread.py
+++ b/src/installation_thread.py
@@ -813,6 +813,21 @@ class InstallationThread(threading.Thread):
                             line = '# autologin=%s' % username
                             line = line[1:]
                         lxdm_conf.write(line)
+
+            # Systems with LightDM as the Desktop Manager
+            elif self.desktop_manager == 'lightdm':
+                lightdm_conf_path = os.path.join(self.dest_dir, "etc/lightdm/lightdm.conf")
+                # Ideally, use configparser for the ini conf file, but just do
+                # a simple text replacement for now
+                text = []
+                with open(lightdm_conf_path, "rt") as lightdm_conf:
+                    text = lightdm_conf.readlines()
+
+                with open(lightdm_conf_path, "wt") as lightdm_conf:
+                    for line in text:
+                        if '#autologin-user=' in line:
+                            line = 'autologin-user=%s\n' % username
+                        lightdm_conf.write(line)
                 
 
         # Let's start without using hwdetect for mkinitcpio.conf.


### PR DESCRIPTION
I'm currently using a patched version of Cnchi for my Unity-for-Arch LiveCD project. It's a really nice installer :D

I know Antergos doesn't support LightDM as the display manager, but would it be possible to merge this pull request, which adds support for autologin with LightDM?

Thanks!
