### PR TITLE
Use /etc/sudoers.d/ to avoid overwriting /etc/sudoers

### DIFF
--- a/arch-setup
+++ b/arch-setup
@@ -4682,12 +4682,8 @@ configure_system() {
                     DIALOG --inputbox $"Enter your user name (no spaces):" 9 40 2>${ANSWER} || return 1
                     USER_NAME_TMP=$(cat ${ANSWER})
                     USER_NAME=${USER_NAME_TMP,,}
-                    rm -f ${DESTDIR}/etc/sudoers
-                    echo "root ALL=(ALL) ALL" > ${DESTDIR}/etc/sudoers
-                    echo "${USER_NAME} ALL=(ALL) ALL" >> ${DESTDIR}/etc/sudoers
-                    #cp -f /arch/sudoers ${DESTDIR}/etc/sudoers
-                    #sed -i "s|^cinnarch|${USER_NAME}|g" ${DESTDIR}/etc/sudoers
-                    chmod 440 ${DESTDIR}/etc/sudoers
+                    echo "${USER_NAME} ALL=(ALL) ALL" >> ${DESTDIR}/etc/sudoers.d/installer
+                    chmod 440 ${DESTDIR}/etc/sudoers.d/installer
 
                     DIALOG --inputbox $"Enter your full name:" 9 40 2>${ANSWER} || return 1
                     USER_FULL_NAME=$(cat ${ANSWER})

--- a/src/installation_thread.py
+++ b/src/installation_thread.py
@@ -725,10 +725,9 @@ class InstallationThread(threading.Thread):
         password = self.settings.get('password')
         hostname = self.settings.get('hostname')
         
-        sudoers_path = os.path.join(self.dest_dir, "etc/sudoers")
+        sudoers_path = os.path.join(self.dest_dir, \
+                                    "etc/sudoers.d/installer")
         with open(sudoers_path, "wt") as sudoers:
-            sudoers.write('# Sudoers file\n')
-            sudoers.write('root ALL=(ALL) ALL\n')
             sudoers.write('%s ALL=(ALL) ALL\n' % username)
         
         subprocess.check_call(["chmod", "440", sudoers_path])


### PR DESCRIPTION
This pull request changes both the text and GUI installer so that the sudo rule is written to `/etc/sudoers.d/installer`. This avoids having to overwrite `/etc/sudoers`, which contains many comments and settings that may be useful to users.
