### PR TITLE
Fix GRUB 2 locale

### DIFF
--- a/src/installation_thread.py
+++ b/src/installation_thread.py
@@ -609,7 +609,8 @@ class InstallationThread(threading.Thread):
             # ignore if exists
             pass
 
-        self.chroot(['sh', '-c', 'LANG=%s /usr/sbin/grub-mkconfig -o /boot/grub/grub.cfg' % code])
+        locale = self.settings.get("locale")
+        self.chroot(['sh', '-c', 'LANG=%s /usr/sbin/grub-mkconfig -o /boot/grub/grub.cfg' % locale])
         
         self.chroot_umount()
 


### PR DESCRIPTION
The current GRUB 2 installation code has a couple problems:
- It copies `/boot/grub/locale/en@quot.mo` to `/boot/grub/locale/%s.mo.gz`
  - The gz file is not gzip compressed
  - This will make GRUB 2 always in English
  - There's no need to copy anything. If you look at `/usr/sbin/grub-install`, it contains:

``` sh
# Copy gettext files
mkdir -p "${grubdir}"/locale/
for dir in "${localedir}"/*; do
    if test -f "$dir/LC_MESSAGES/grub.mo"; then
        cp -f "$dir/LC_MESSAGES/grub.mo" "${grubdir}/locale/${dir##*/}.mo"
    fi
done
```

All the supported GRUB 2 languages are already copied to /boot/grub/locale/
- `grub-install` is run instead of `LANG=something grub-install`, so GRUB always ends up in English.

This pull request fixes both issues :)
