### PR TITLE
Fix problem where the locale is not saved if the locale is only used in one country

### DIFF
--- a/src/location.py
+++ b/src/location.py
@@ -191,18 +191,22 @@ class Location(Gtk.Box):
         selected = self.treeview.get_selection()
         if selected:
             (ls, iter) = selected.get_selected()
-            if iter:
-                country = ls.get_value(iter, 0)
-                lang_code = self.settings.get("language_code")
-                for mylocale in self.locales:
-                    if self.locales[mylocale] == country:
-                        self.settings.set("locale", mylocale)
-                        try:
-                            import locale
-                            locale.setlocale(locale.LC_ALL, mylocale)
-                            log.debug(_("locale changed to : %s") % mylocale)
-                        except (ImportError, locale.Error):
-                            log.debug(_("Can't change to locale '%s'") % mylocale)
+
+            if not iter:
+                iter = ls.get_iter_first()
+
+            country = ls.get_value(iter, 0)
+            lang_code = self.settings.get("language_code")
+            for mylocale in self.locales:
+                if self.locales[mylocale] == country:
+                    self.settings.set("locale", mylocale)
+                    try:
+                        import locale
+                        locale.setlocale(locale.LC_ALL, mylocale)
+                        log.debug(_("locale changed to : %s") % mylocale)
+                    except (ImportError, locale.Error):
+                        log.debug(_("Can't change to locale '%s'") % mylocale)
+
         return True
 
     def get_prev_page(self):


### PR DESCRIPTION
The code currently has a major problem where the locale does not get saved if the locale is only used in one country.

In location.py, the code skips the country selection page if the locale is only used in one country:

``` python
        if self.treeview_items == 1:
            # If we have only one option, don't bother our beloved user
            self.store_values()
            if direction == 'forwards':
                GLib.idle_add(self.forward_button.clicked)
            else:
                GLib.idle_add(self.backwards_button.clicked)
        else:
            self.select_first_treeview_item()
            self.translate_ui()
```

The problem is that `iter = None` in `store_values()` because the user can't select something on a hidden page. As a result, the locale is not stored, causing problems after the system is installed.

``` python
    def store_values(self):
        selected = self.treeview.get_selection()
        if selected:
            (ls, iter) = selected.get_selected()
            if iter:
```

This pull request changes the code to choose the first country in the list by default. So, now it's like:

``` python
    def store_values(self):
        selected = self.treeview.get_selection()
        if selected:
            (ls, iter) = selected.get_selected()

            if not iter:
                iter = ls.get_iter_first()
```

With this change, both single-country locales and multiple-country locales work perfectly. Could someone please merge this pull request? The current code causes major problems, such as every line being uncommented in /etc/locale.gen), with single-country locales like zh_CN.

Thanks!
