### PR TITLE
Updated MATE.

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -75,6 +75,7 @@
         <pkgname>sharutils</pkgname>
         <pkgname>unace</pkgname>
         <pkgname>uudeview</pkgname>
+        <pkgname>unrar</pkgname>
         <pkgname>xz</pkgname>
         <pkgname>zip</pkgname>
     </nox>
@@ -232,39 +233,48 @@
     </razor_desktop>
 
     <mate_desktop>
+        <pkgname>cdrkit</pkgname>
         <pkgname>faenza-hotot-icon</pkgname>
         <pkgname>faenza-icon-theme</pkgname>
         <pkgname>gksu</pkgname>
+        <pkgname>gst-libav</pkgname>
+        <pkgname>gst-plugins-bad</pkgname>
+        <pkgname>gst-plugins-base</pkgname>
+        <pkgname>gst-plugins-good</pkgname>
+        <pkgname>gst-plugins-ugly</pkgname>
         <pkgname>gst-vaapi</pkgname>
-        <pkgname>gstreamer0.10-plugins</pkgname>
+        <pkgname>gstreamer0.10-plugins</pkgname>  <!-- Group -->
         <pkgname>gstreamer0.10-vaapi</pkgname>
+        <pkgname>gvfs-mtp</pkgname>
         <pkgname>gvfs-smb</pkgname>
         <pkgname>hotot-gtk3</pkgname>
         <pkgname>mate</pkgname> <!-- Group -->
         <pkgname>mate-applets</pkgname>
-        <pkgname>mate.calc</pkgname> 
-        <!-- <pkgname>mate-applet-softupd</pkgname> -->
-        <pkgname>mate-disk-utility</pkgname>
-        <pkgname>mate-document-viewer</pkgname> 
-        <pkgname>mate-file-archiver</pkgname> 
-        <pkgname>mate-file-manager-open-terminal</pkgname> 
-        <pkgname>mate-media</pkgname>
-        <pkgname>mate-media-pulseaudio</pkgname> 
-        <pkgname>mate-menu-editor</pkgname> 
-        <pkgname>mate-image-viewer</pkgname> 
+        <pkgname>mate-calc</pkgname>
+        <pkgname>mate-character-map</pkgname>
+        <pkgname>mate-document-viewer</pkgname>
+        <pkgname>mate-file-archiver</pkgname>
+        <pkgname>mate-file-manager-open-terminal</pkgname>
+        <pkgname>mate-image-viewer</pkgname>
+        <pkgname>mate-media-pulseaudio</pkgname>
+        <pkgname>mate-menu-editor</pkgname>
+        <pkgname>mate-netspeed</pkgname>
+        <pkgname>mate-power-manager</pkgname>
+        <pkgname>mate-screensaver</pkgname>
+        <pkgname>mate-sensors-applet</pkgname>
+        <pkgname>mate-system-monitor</pkgname>
         <pkgname>mate-terminal</pkgname>
-        <pkgname>mate-power-manager</pkgname> 
-        <pkgname>mate-screensaver</pkgname> 
-        <pkgname>mate-system-monitor</pkgname> 
-        <pkgname>mate-system-tools</pkgname> 
-        <pkgname>mate-text-editor</pkgname> 
-        <pkgname>mate-utils</pkgname> 
-        <!-- <pkgname>mintmenu</pkgname> -->
-        <pkgname>network-manager-applet</pkgname>
+        <pkgname>mate-text-editor</pkgname>
+        <pkgname>mate-utils</pkgname>
+        <pkgname nm='true' name='NetworkManager'>network-manager-applet</pkgname>
         <pkgname>networkmanager-openvpn</pkgname>
         <pkgname>networkmanager-pptp</pkgname>
-        <pkgname>xdg-user-dirs</pkgname>
+        <pkgname>pidgin</pkgname>
+        <pkgname>shotwell</pkgname>
+        <pkgname>transmission-gtk</pkgname>
         <pkgname>xdg-user-dirs-gtk</pkgname>
+        <pkgname>xfburn</pkgname>
+        <pkgname>xnoise</pkgname>
         <pkgname>zukitwo-themes</pkgname>
     </mate_desktop>
 

--- a/src/desktop_environments.py
+++ b/src/desktop_environments.py
@@ -52,7 +52,7 @@ FEATURES = {
     'cinnamon' : [ "aur", "bluetooth", "cups", "fonts", "office", "firewall", "third_party" ],
     'gnome' : [ "aur", "bluetooth", "cups", "fonts", "gnome_extra", "office", "firewall", "third_party" ],
     'kde' : [ "aur", "bluetooth", "cups", "fonts", "office", "firewall", "third_party" ],
-    'mate' : [ "aur", "bluetooth", "cups", "fonts", "office", "firewall", "third_party" ],
+    'mate' : [ "aur", "cups", "fonts", "office", "firewall", "third_party" ],
     'enlightenment' : [ "aur", "bluetooth", "cups", "fonts", "office", "firewall", "third_party" ],
     'nox' : [ "aur", "bluetooth", "cups", "fonts", "firewall" ],
     'openbox' : [ "aur", "bluetooth", "cups", "fonts", "office", "visual", "firewall", "third_party" ],


### PR DESCRIPTION
Hi,

Here is an update for MATE. Wish I'd seen the `testing` branch earlier, it would have saved me some time. Looks like you've cleaned up the code somewhat :-)
- I've cleaned up the MATE package list that provide slightly less than a full MATE install but all the essential and useful stuff. I've added some applications that feature in GNOME3/Cinnamon that appear to be your preferred choices. I removed some MATE applications that are community contributed.
- Currently `mate-bluetooth` requires `bluez4` which is now only available from the AUR. Therefore I've removed `bluetooth` from the features for MATE.
- I've added `unrar` to the archivers, as `mate-file-archiver` recently added support for RAR 5.x.
- I haven't update `cli_installer` as I'm not sure if that is still relevant?

Looking forward to seeing MATE in Antergos soon :-)

Regards, Martin.
