### PR TITLE
don't throw error if 10_archlinux is not found

### DIFF
--- a/scripts/10_antergos
+++ b/scripts/10_antergos
@@ -18,7 +18,7 @@ set -e
 
 # Disable 10_linux
 chmod -x /etc/grub.d/10_linux
-chmod -x /etc/grub.d/10_archlinux
+"chmod -x /etc/grub.d/10_archlinux" || true
 
 prefix="/usr"
 exec_prefix="/usr"


### PR DESCRIPTION
sorry, just found this problem during testing...
