### PR TITLE
Add "seahorse" package to gnome desktop

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -131,6 +131,7 @@
         <pkgname>xfburn</pkgname>
         <pkgname>xnoise</pkgname>
         <pkgname>xscreensaver</pkgname>
+        <pkgname>seahorse</pkgname>
     </gnome_desktop>
 
     <cinnamon_desktop>


### PR DESCRIPTION
I think this tool is really missing in default installation of Gnome...