### PR TITLE
add gsimplecal to openbox install

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -282,6 +282,7 @@
         <pkgname>gnome-disk-utility</pkgname>
         <pkgname>gnome-mplayer</pkgname>
         <pkgname>gpicview</pkgname>
+        <pkgname>gsimplecal</pkgname>
         <pkgname>gst-libav</pkgname>
         <pkgname>gst-plugins-bad</pkgname>
         <pkgname>gst-plugins-base</pkgname>


### PR DESCRIPTION
`tint2` is configured to use `gsimplecal` but it is not installed by default.