### PR TITLE
Add gnome calendar to Gnome DE

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -108,6 +108,7 @@
         <pkgname>gedit</pkgname>
         <pkgname>gnome-backgrounds</pkgname>
         <pkgname>gnome-calculator</pkgname>
+        <pkgname>gnome-calendar</pkgname>
         <pkgname>gnome-contacts</pkgname>
         <pkgname>gnome-control-center</pkgname>
         <pkgname>gnome-documents</pkgname>


### PR DESCRIPTION
This is new core app to manage users calendar, very well integrated to gnome