### PR TITLE
Add tracker package to gnome DE

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -142,6 +142,7 @@
         <pkgname>pidgin</pkgname>
         <pkgname>seahorse</pkgname>
         <pkgname>totem</pkgname>
+        <pkgname>tracker</pkgname>
         <pkgname>transmission-gtk</pkgname>
         <pkgname>xdg-user-dirs-gtk</pkgname>
         <pkgname>xscreensaver</pkgname>


### PR DESCRIPTION
File search dont work in activities overview, without indexing of tracker.