### PR TITLE
Correct speed format

### DIFF
--- a/cnchi/download/download_requests.py
+++ b/cnchi/download/download_requests.py
@@ -197,10 +197,13 @@ class Download(object):
                                 if old_percent != percent:
                                     self.queue_event('percent', percent)
 
-                                bps = (completed_length // (time.clock() - start)) / 1024
-                                if bps > 1024:
-                                    Mbps = bps / 1024 / 1024
+                                bps = (completed_length // (time.clock() - start)) * 8
+                                if bps >= (1024 * 1024):
+                                    Mbps = bps / (1024 * 1024)
                                     progress_text = "{0}% {1:.2f} Mbps".format(int(percent * 100), Mbps)
+                                elif bps >= 1024:
+                                    Kbps = bps / 1024
+                                    progress_text = "{0}% {1:.2f} Kbps".format(int(percent * 100), Kbps)
                                 else:
                                     progress_text = "{0}% {1:.2f} bps".format(int(percent * 100), bps)
                                 self.queue_event('progress_bar_show_text', progress_text)


### PR DESCRIPTION
(completed_length // (time.clock() - start)) returns bytes. 
So multiply it by 8 to get bits per second and then convert to kbps and mbps.