### PR TITLE
Enable detection of linux-* named initrd. Fixes #442

### DIFF
--- a/scripts/10_antergos
+++ b/scripts/10_antergos
@@ -255,6 +255,8 @@ while [ "x$list" != "x" ] ; do
 	   "initrd-${version}" "initramfs-${version}.img" \
 	   "initrd.img-${alt_version}" "initrd-${alt_version}.img" \
 	   "initrd-${alt_version}" "initramfs-${alt_version}.img" \
+           "initrd-linux-${version}" "initramfs-linux-${version}.img" \
+           "initrd-linux-${alt_version}" "initramfs-linux-${alt_version}.img" \
 	   "initramfs-genkernel-${version}" \
 	   "initramfs-genkernel-${alt_version}" \
 	   "initramfs-genkernel-${GENKERNEL_ARCH}-${version}" \


### PR DESCRIPTION
My current fix just searches for (initrd|initramfs)-linux-(${version}|${alt_version}).

Previous behavior with linux-lts installed:

```bash
 ~ $ sudo grub-mkconfig -o /boot/grub/grub.cfg
Generating grub configuration file ...
Found theme: /boot/grub/themes/Antergos-Default/theme.txt
Found linux image: /boot/vmlinuz-linux-lts
Found linux image: /boot/vmlinuz-linux
Found initrd image: /boot/initramfs-linux.img
done
```

current behaviour:

``` bash
 ~ $ sudo grub-mkconfig -o /boot/grub/grub.cfg
Generating grub configuration file ...
Found theme: /boot/grub/themes/Antergos-Default/theme.txt
Found linux image: /boot/vmlinuz-linux-lts
Found initrd image: /boot/initramfs-linux-lts.img
Found linux image: /boot/vmlinuz-linux
Found initrd image: /boot/initramfs-linux.img
done
```