### PR TITLE
Update 10_antergos

### DIFF
--- a/scripts/10_antergos
+++ b/scripts/10_antergos
@@ -119,34 +119,28 @@ linux_entry ()
       fi
       echo "menuentry '$(echo "$title" | grub_quote)' ${CLASS} \$menuentry_id_option 'gnulinux-$version-$type-$boot_device_id' {" | sed "s/^/$submenu_indentation/"
   else
-      if [ "$is_arch" ]; then
-            if [ -z "${entry+xxx}" ]; then
-                  entry="0"
-            fi
-            check=$(( $entry % 2 ))
-            if ([ "$entry" != "0" ] && [ "$check" -eq "0" ]) || [ "$entry" == "0" ]; then
-                  if [ "$version" == "linux" ]; then
-	                title="$(gettext_printf "%s" "${os}")"
-	          elif [ "$version" == "linux-lts" ]; then
-	                title="$(gettext_printf "%s LTS Kernel" "${os}")"
-	          else
-	                title="$(gettext_printf "%s, with %s Kernel" "${os}" "${version}")"
-	          fi
-                  entry=$((entry + 1))
-            else
-                  if [ "$version" == "linux" ]; then
-	                title="$(gettext_printf "%s - Fallback" "${os}")"
-	          elif [ "$version" == "linux-lts" ]; then
-	                title="$(gettext_printf "%s LTS Kernel - Fallback" "${os}")"
-	          else
-	                title="$(gettext_printf "%s, with %s Kernel - Fallback" "${os}" "${version}")"
-	          fi
-                  entry=$((entry + 1))
-            fi
+	if [ "$is_arch" ]; then
+		if [ x$type != xfallback ]; then
+        	if [ "$version" == "linux" ]; then
+                title="$(gettext_printf "%s" "${os}")"
+          	elif [ "$version" == "linux-lts" ]; then
+                title="$(gettext_printf "%s LTS Kernel" "${os}")"
+          	else
+                title="$(gettext_printf "%s, with %s Kernel" "${os}" "${version}")"
+          	fi
+        else
+			if [ "$version" == "linux" ]; then
+                title="$(gettext_printf "%s - Fallback" "${os}")"
+          	elif [ "$version" == "linux-lts" ]; then
+                title="$(gettext_printf "%s LTS Kernel - Fallback" "${os}")"
+          	else
+                title="$(gettext_printf "%s, with %s Kernel - Fallback" "${os}" "${version}")"
+          	fi
+        fi
             
-          os="$title"
-      fi
-      echo "menuentry '$(echo "$os" | grub_quote)' ${CLASS} \$menuentry_id_option 'gnulinux-simple-$boot_device_id' {" | sed "s/^/$submenu_indentation/"
+  		os="$title"
+	fi
+	echo "menuentry '$(echo "$os" | grub_quote)' ${CLASS} \$menuentry_id_option 'gnulinux-simple-$boot_device_id' {" | sed "s/^/$submenu_indentation/"
   fi      
   if [ x$type != xrecovery ] && [ x$type != xfallback ] ; then
       save_default_entry | grub_add_tab
@@ -185,27 +179,18 @@ linux_entry ()
 	echo	'$(echo "$message" | grub_quote)'
 	linux	${rel_dirname}/${basename} root=${linux_root_device_thisversion} rw ${args}
 EOF
-  if test -n "${initrd}" ; then
-      if [ "$is_arch" ]; then
-            if [ -z "${counter+xxx}" ]; then
-                  counter="0"
-            fi
-            check=$(( $counter % 2 ))
-            if (([ "$counter" != "0" ] && [ "$check" -eq "0" ]) || [ "$counter" == "0" ]); then
-                  counter=$((counter + 1))
-            else
-                  initrd="initramfs-${version}-fallback.img"
-                  counter=$((counter + 1))
-            fi
-      fi
+	if test -n "${initrd}" ; then
+		if [ "$is_arch" ] && [ x$type = xfallback ] ; then
+			initrd="initramfs-${version}-fallback.img"
+		fi
     # TRANSLATORS: ramdisk isn't identifier. Should be translated.
-    message="$(gettext_printf "Loading initial ramdisk ...")"
-    sed "s/^/$submenu_indentation/" << EOF
+	message="$(gettext_printf "Loading initial ramdisk ...")"
+	sed "s/^/$submenu_indentation/" << EOF
 	echo	'$(echo "$message" | grub_quote)'
 	initrd	${intel_ucode} ${rel_dirname}/${initrd}
 EOF
-  fi
-  sed "s/^/$submenu_indentation/" << EOF
+	fi
+	sed "s/^/$submenu_indentation/" << EOF
 }
 EOF
 }
@@ -241,7 +226,13 @@ submenu_indentation=""
 
 is_top_level=true
 while [ "x$list" != "x" ] ; do
-  linux=`version_find_latest $list`
+  if [ $(echo $list | grep -q '[0-9]') ]; then
+    linux=`version_find_latest $list`
+  else
+    artmp=($list)
+    linux=${artmp[0]}
+  fi
+  
   gettext_printf "Found linux image: %s\n" "$linux" >&2
   basename=`basename $linux`
   dirname=`dirname $linux`
@@ -288,7 +279,7 @@ while [ "x$list" != "x" ] ; do
     linux_root_device_thisversion=${GRUB_DEVICE}
   fi
 
-  if [ "x$is_top_level" = xtrue ] && [ "x${GRUB_DISABLE_SUBMENU}" != xy ]; then
+  if [ "x$is_top_level" = xtrue ] && [ "x${GRUB_DISABLE_SUBMENU}" != xtrue ]; then
     linux_entry "${OS}" "${version}" simple \
     "${GRUB_CMDLINE_LINUX} ${GRUB_CMDLINE_LINUX_DEFAULT}"
 


### PR DESCRIPTION
fix Issues when generating fallback entries

Desc: 
1.The common usage for grub variables (GRUB_DISABLE_SUBMENU) is true or false, so changing the check according to that, 
2.When generation the menu list using submenu it generates the names and the initrd wrong since it was using a counter (or entry counter) and it mess up with the first entry (the one outside the submenu) now we check in base of the parameter $type so it's more accurate
3.when linux=`version find latest $list` it was grabbing lts kernel version first, and i think it's most likely to prefer on the non lts version for the first entries

I did a bunch of test and seems to be working as expected now

Hope you guys like it :smile: 