### PR TITLE
Taiwan is not part of China

### DIFF
--- a/data/locale/iso3366-1.xml
+++ b/data/locale/iso3366-1.xml
@@ -217,7 +217,7 @@
 	<code value="SE">Sweden</code>
 	<code value="CH">Switzerland</code>
 	<code value="SY">Syrian Arab Republic</code>
-	<code value="TW">Taiwan, Province of China</code>
+	<code value="TW">Taiwan</code>
 	<code value="TJ">Tajikistan</code>
 	<code value="TZ">Tanzania, United Republic of</code>
 	<code value="TH">Thailand</code>


### PR DESCRIPTION
Due to present ISO standards, any statement made on a form on the
internet would change "Taiwan" as "Taiwan, Province of China". This is a
tremendous insult to Taiwanese community. Please change this mistake and
allow the Taiwanese people to proudly select their country as "Taiwan",
not "Taiwan, Province of China".

Please refer to
https://www.change.org/p/iso-change-the-present-taiwan-province-of-china-to-taiwan-4abd1e75-f698-4770-94dc-0a34e6e35819
for more information.