### PR TITLE
KDE4 package removed

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -376,7 +376,6 @@
         <pkgname>kcalc</pkgname>
         <pkgname>kde-gtk-config</pkgname>
         <pkgname>kdeadmin-kuser</pkgname>
-        <pkgname>kdeartwork-desktopthemes</pkgname>
         <pkgname>kdeartwork-iconthemes</pkgname>
         <pkgname>kdeartwork-kscreensaver</pkgname>
         <pkgname>kdeartwork-styles</pkgname>


### PR DESCRIPTION
kdeartwork-desktopthemes has been removed from [extra]

https://www.archlinux.org/packages/extra/x86_64/kdeartwork-desktopthemes/