### PR TITLE
Update packages.xml

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -381,7 +381,7 @@
 				<pkgname>kdebase-kdepasswd</pkgname>
 				<pkgname>kdebase-kdialog</pkgname>
 				<pkgname>kdebase-kfind</pkgname>
-				<pkgname>kdegraphics-ksnapshot</pkgname>
+				<pkgname>spectacle</pkgname>
 				<pkgname>kdegraphics-okular</pkgname>
 				<pkgname>kdegraphics-thumbnailers</pkgname>
 				<pkgname>kdemultimedia-ffmpegthumbs</pkgname>


### PR DESCRIPTION
> After 14 years of being a part of KDE, KSnapshot has been retired and replaced with a new screenshot application, Spectacle.

https://www.kde.org/announcements/announce-applications-15.12.0.php

(The package is still in testing but I'd rather have the jump on it)