### PR TITLE
change default_groups

### DIFF
--- a/cnchi/installation/install.py
+++ b/cnchi/installation/install.py
@@ -1158,7 +1158,7 @@ class Installation(object):
 
         # Setup user
 
-        default_groups = 'lp,video,network,storage,wheel,audio'
+        default_groups = 'wheel'
 
         if self.vbox:
             # Why there is no vboxusers group? Add it ourselves.


### PR DESCRIPTION
`lp`, `video`, `network`, `storage` and `audio` are pre-systemd groups, which are no longer needed, and can even cause some problems.

[Arch Wiki on pre-systemd groups](https://wiki.archlinux.org/index.php/users_and_groups#Pre-systemd_groups)

> These groups used to be needed before arch migrated to systemd. That is no longer the case, as long as the logind session is not broken. The groups can even cause some functionality to break.

[Arch Wiki on problems which can occur if using those groups](https://wiki.archlinux.org/index.php/SysVinit#Migration_to_systemd)

> For example, the audio group will break fast user switching and allows applications to block software mixing.