### PR TITLE
Add gnome-keyring package to MATE installation

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -263,6 +263,7 @@
 				<pkgname>eom</pkgname>
 				<pkgname>galculator-gtk2</pkgname>
 				<pkgname>gksu</pkgname>
+				<pkgname>gnome-keyring</pkgname>
 				<pkgname>gvfs-mtp</pkgname>
 				<pkgname>mate</pkgname> <!-- Group -->
 				<pkgname>mate-applets</pkgname>


### PR DESCRIPTION
This will fix saving passwords to keyring. (i.e. in Octopi)