### PR TITLE
split on int() type

### DIFF
--- a/cnchi/installation/zfs.py
+++ b/cnchi/installation/zfs.py
@@ -833,9 +833,9 @@ class InstallationZFS(GtkBaseBox):
             if 'M' in pool_size_str:
                 pool_size //= 1024
             elif 'T' in pool_size_str:
-                pool_size = int(pool_size[:-1]) * 1024
+                pool_size = pool_size * 1024
             elif 'P' in pool_size_str:
-                pool_size = int(pool_size[:-1]) * 1024 * 1024
+                pool_size = pool_size * 1024 * 1024
         except (subprocess.CalledProcessError, ValueError) as err:
             logging.warning(
                 "Can't get zfs %s pool size: %s",


### PR DESCRIPTION
The variable 'pool_size' is converted to type 'int' in all cases before the second if/elif/elif test so it is always a mistake to use a string operator (split, via '[:1]') at that point.  This was causing all attempts at installation with ZFS to fail, with this change I've been able to install Antergos with a ZFS filesystem for the root partition.