### PR TITLE
Added gnome-font-viewer to Cinnamon flavour

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -170,6 +170,7 @@
 				<pkgname>gnome-calculator</pkgname>
 				<pkgname>gnome-common</pkgname>
 				<pkgname>gnome-disk-utility</pkgname>
+				<pkgname>gnome-font-viewer</pkgname>
 				<pkgname>gnome-keyring</pkgname>
 				<pkgname>gnome-music</pkgname>
 				<pkgname>gnome-photos</pkgname>


### PR DESCRIPTION
In Cinnamon is unable to open fonts(ttf) by default. This will fix that.