### PR TITLE
Fix: Allow adding of applets to Cinnamon sessions

### DIFF
--- a/scripts/set-settings
+++ b/scripts/set-settings
@@ -90,6 +90,8 @@ if [[ ${DESKTOP} == 'cinnamon' ]]; then
 
 	# Set enabled applets
 	gsettings set org.cinnamon enabled-applets "['panel1:left:1:menu@cinnamon.org:0', 'panel1:left:2:panel-launchers@cinnamon.org:1', 'panel1:left:3:window-list@cinnamon.org:2', 'panel1:right:0:removable-drives@cinnamon.org:3', 'panel1:right:1:keyboard@cinnamon.org:4', 'panel1:right:2:bluetooth@cinnamon.org:5', 'panel1:right:4:systray@cinnamon.org:7', 'panel1:right:5:power@cinnamon.org:8', 'panel1:right:6:network@cinnamon.org:6', 'panel1:right:7:sound@cinnamon.org:9', 'panel1:right:8:calendar@cinnamon.org:10', 'panel1:right:9:settings@cinnamon.org:11']"
+	# Accordingly set next-applet-id
+	gsettings set org.cinnamon next-applet-id 12
 
 	# Disable keyboard flags
 	gsettings set org.cinnamon keyboard-applet-use-flags "false"


### PR DESCRIPTION
By default the cinnamon setting does not accept user added applets.
Obviously because the setting `gsettings set org.cinnamon.next-applet-id` is not set and hence the next applet recevies the id 1 (which is already allocated).

This patch should fix this issue for new installations.

See https://forum.antergos.com/topic/4825/cinnamon-applets-not-showing-up/10  and https://github.com/linuxmint/Cinnamon/issues/5665