### PR TITLE
changed "KDE" to "KDE Plasma"

### DIFF
--- a/cnchi/desktop_info.py
+++ b/cnchi/desktop_info.py
@@ -54,7 +54,7 @@ NAMES = {
     'xfce': "Xfce",
     'openbox': "Openbox",
     'enlightenment': "Enlightenment",
-    'kde': "KDE",
+    'kde': "KDE Plasma",
     'lxqt': "LXQt",
     'mate': "MATE"
 }


### PR DESCRIPTION
the description of the DE says KDE's Plasma Desktop which is great but I think the entry should also be updated as per the wishes of what the KDE project wants people to refer to Plasma as.