### PR TITLE
New mirrors screen

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+[2017-09-08 17:57:32 +0200]  Add reflector to all installations                                         karasu      {5feaeb3b}
+[2017-09-08 17:53:37 +0200]  Changes in deepin package list                                             karasu      {04973aa7}
+[2017-08-31 01:54:20 +0200]  Change mouse cursor when dragging a mirror                                 karasu      {7b2ced69}
 [2017-08-30 16:57:37 +0200]  Add a source comment                                                       karasu      {d9dee641}
 [2017-08-30 16:54:34 +0200]  Fix bug in forward button when changing options in mirrors screen          karasu      {e163e1a5}
 [2017-08-30 16:51:11 +0200]  hide/show mirrors listboxes                                                karasu      {b8ae0f25}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 11:41:22 +0200]  Fix typo and add a debug warning                                           karasu      {1e4b10d9}
 [2017-08-30 04:07:45 +0200]  Fixed two unused variables (antbs)                                         karasu      {d05a241d}
 [2017-08-30 03:48:32 +0200]  Forgot to remove the option from the run script                            karasu      {9ccb1687}
 [2017-08-30 03:43:56 +0200]  Disable rank mirrors option (now we have a full screen to do it)           karasu      {322e9bbc}

--- a/CHANGES
+++ b/CHANGES
@@ -1,2 +1,3 @@
+[2017-08-29 19:31:51 +0200]  Going somewhere with drag and drop (or so it seems)                        karasu      {1959880c}
 [2017-08-29 10:26:04 +0200]  In the middle of something                                                 karasu      {5f34184c}
 [2017-08-28 03:20:27 +0200]  Adding new mirrors screen (wip)                                            karasu      {f88628ed}

--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,1 @@
+[2017-08-28 03:20:27 +0200]  Adding new mirrors screen (wip)                                            karasu      {f88628ed}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 16:57:37 +0200]  Add a source comment                                                       karasu      {d9dee641}
 [2017-08-30 16:54:34 +0200]  Fix bug in forward button when changing options in mirrors screen          karasu      {e163e1a5}
 [2017-08-30 16:51:11 +0200]  hide/show mirrors listboxes                                                karasu      {b8ae0f25}
 [2017-08-30 15:48:44 +0200]  Better radiobuttons placement in mirrors screen                            karasu      {d87e2356}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 12:37:43 +0200]  Fix location listbox labels size (was too small)                           karasu      {1298d5f2}
 [2017-08-30 11:41:22 +0200]  Fix typo and add a debug warning                                           karasu      {1e4b10d9}
 [2017-08-30 04:07:45 +0200]  Fixed two unused variables (antbs)                                         karasu      {d05a241d}
 [2017-08-30 03:48:32 +0200]  Forgot to remove the option from the run script                            karasu      {9ccb1687}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-09-09 17:37:56 +0200]  Fix typo in packages.xml                                                   karasu      {089a4e92}
 [2017-09-09 17:37:29 +0200]  Fix typo in packages.xml                                                   karasu      {3d1baf63}
 [2017-09-08 17:57:57 +0200]  Add reflector to all installations                                         karasu      {fe1b0892}
 [2017-09-08 17:57:32 +0200]  Add reflector to all installations                                         karasu      {5feaeb3b}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 04:07:45 +0200]  Fixed two unused variables (antbs)                                         karasu      {d05a241d}
 [2017-08-30 03:48:32 +0200]  Forgot to remove the option from the run script                            karasu      {9ccb1687}
 [2017-08-30 03:43:56 +0200]  Disable rank mirrors option (now we have a full screen to do it)           karasu      {322e9bbc}
 [2017-08-30 03:24:28 +0200]  Changes are saved.                                                         karasu      {9b1c6b65}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-29 23:43:39 +0200]  Need to know how to pass a widget (or a reference) when doing dnd          karasu      {1cf8ad87}
 [2017-08-29 19:31:51 +0200]  Going somewhere with drag and drop (or so it seems)                        karasu      {1959880c}
 [2017-08-29 10:26:04 +0200]  In the middle of something                                                 karasu      {5f34184c}
 [2017-08-28 03:20:27 +0200]  Adding new mirrors screen (wip)                                            karasu      {f88628ed}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 03:05:33 +0200]  It's alive! (dnd works)                                                    karasu      {f49ec9ce}
 [2017-08-29 23:43:39 +0200]  Need to know how to pass a widget (or a reference) when doing dnd          karasu      {1cf8ad87}
 [2017-08-29 19:31:51 +0200]  Going somewhere with drag and drop (or so it seems)                        karasu      {1959880c}
 [2017-08-29 10:26:04 +0200]  In the middle of something                                                 karasu      {5f34184c}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 03:24:28 +0200]  Changes are saved.                                                         karasu      {9b1c6b65}
 [2017-08-30 03:05:33 +0200]  It's alive! (dnd works)                                                    karasu      {f49ec9ce}
 [2017-08-29 23:43:39 +0200]  Need to know how to pass a widget (or a reference) when doing dnd          karasu      {1cf8ad87}
 [2017-08-29 19:31:51 +0200]  Going somewhere with drag and drop (or so it seems)                        karasu      {1959880c}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 16:51:11 +0200]  hide/show mirrors listboxes                                                karasu      {b8ae0f25}
 [2017-08-30 15:48:44 +0200]  Better radiobuttons placement in mirrors screen                            karasu      {d87e2356}
 [2017-08-30 12:37:43 +0200]  Fix location listbox labels size (was too small)                           karasu      {1298d5f2}
 [2017-08-30 11:41:22 +0200]  Fix typo and add a debug warning                                           karasu      {1e4b10d9}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+[2017-09-09 17:37:29 +0200]  Fix typo in packages.xml                                                   karasu      {3d1baf63}
+[2017-09-08 17:57:57 +0200]  Add reflector to all installations                                         karasu      {fe1b0892}
 [2017-09-08 17:57:32 +0200]  Add reflector to all installations                                         karasu      {5feaeb3b}
 [2017-09-08 17:53:37 +0200]  Changes in deepin package list                                             karasu      {04973aa7}
 [2017-08-31 01:54:20 +0200]  Change mouse cursor when dragging a mirror                                 karasu      {7b2ced69}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 03:43:56 +0200]  Disable rank mirrors option (now we have a full screen to do it)           karasu      {322e9bbc}
 [2017-08-30 03:24:28 +0200]  Changes are saved.                                                         karasu      {9b1c6b65}
 [2017-08-30 03:05:33 +0200]  It's alive! (dnd works)                                                    karasu      {f49ec9ce}
 [2017-08-29 23:43:39 +0200]  Need to know how to pass a widget (or a reference) when doing dnd          karasu      {1cf8ad87}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 15:48:44 +0200]  Better radiobuttons placement in mirrors screen                            karasu      {d87e2356}
 [2017-08-30 12:37:43 +0200]  Fix location listbox labels size (was too small)                           karasu      {1298d5f2}
 [2017-08-30 11:41:22 +0200]  Fix typo and add a debug warning                                           karasu      {1e4b10d9}
 [2017-08-30 04:07:45 +0200]  Fixed two unused variables (antbs)                                         karasu      {d05a241d}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 03:48:32 +0200]  Forgot to remove the option from the run script                            karasu      {9ccb1687}
 [2017-08-30 03:43:56 +0200]  Disable rank mirrors option (now we have a full screen to do it)           karasu      {322e9bbc}
 [2017-08-30 03:24:28 +0200]  Changes are saved.                                                         karasu      {9b1c6b65}
 [2017-08-30 03:05:33 +0200]  It's alive! (dnd works)                                                    karasu      {f49ec9ce}

--- a/CHANGES
+++ b/CHANGES
@@ -1,1 +1,2 @@
+[2017-08-29 10:26:04 +0200]  In the middle of something                                                 karasu      {5f34184c}
 [2017-08-28 03:20:27 +0200]  Adding new mirrors screen (wip)                                            karasu      {f88628ed}

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,4 @@
+[2017-08-30 16:54:34 +0200]  Fix bug in forward button when changing options in mirrors screen          karasu      {e163e1a5}
 [2017-08-30 16:51:11 +0200]  hide/show mirrors listboxes                                                karasu      {b8ae0f25}
 [2017-08-30 15:48:44 +0200]  Better radiobuttons placement in mirrors screen                            karasu      {d87e2356}
 [2017-08-30 12:37:43 +0200]  Fix location listbox labels size (was too small)                           karasu      {1298d5f2}

--- a/cnchi/cnchi.py
+++ b/cnchi/cnchi.py
@@ -387,10 +387,6 @@ def parse_options():
         help=_("Do not search for new Cnchi versions online"),
         action="store_true")
     parser.add_argument(
-        "--disable-rank-mirrors",
-        help=_("Does not attempt to rank Arch and Antergos mirrors during installation"),
-        action="store_true")
-    parser.add_argument(
         "-v", "--verbose",
         help=_("Show logging messages to stdout"),
         action="store_true")

--- a/cnchi/features.py
+++ b/cnchi/features.py
@@ -74,7 +74,7 @@ class Features(GtkBaseBox):
     COL_DESCRIPTION = 2
     COL_SWITCH = 3
 
-    def __init__(self, params, prev_page="desktop", next_page="installation_ask"):
+    def __init__(self, params, prev_page="desktop", next_page="mirrors"):
         """ Initializes features ui """
         super().__init__(self, params, "features", prev_page, next_page)
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.336"
+CNCHI_VERSION = "0.14.337"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.324"
+CNCHI_VERSION = "0.14.325"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.339"
+CNCHI_VERSION = "0.14.340"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.335"
+CNCHI_VERSION = "0.14.336"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.327"
+CNCHI_VERSION = "0.14.328"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.330"
+CNCHI_VERSION = "0.14.331"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.325"
+CNCHI_VERSION = "0.14.326"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.322"
+CNCHI_VERSION = "0.14.323"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.340"
+CNCHI_VERSION = "0.14.341"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.326"
+CNCHI_VERSION = "0.14.327"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.332"
+CNCHI_VERSION = "0.14.333"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.333"
+CNCHI_VERSION = "0.14.334"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.331"
+CNCHI_VERSION = "0.14.332"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.334"
+CNCHI_VERSION = "0.14.335"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.328"
+CNCHI_VERSION = "0.14.329"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.323"
+CNCHI_VERSION = "0.14.324"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.337"
+CNCHI_VERSION = "0.14.338"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.329"
+CNCHI_VERSION = "0.14.330"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/info.py
+++ b/cnchi/info.py
@@ -29,7 +29,7 @@
 
 """ Set some Cnchi global constants """
 
-CNCHI_VERSION = "0.14.338"
+CNCHI_VERSION = "0.14.339"
 CNCHI_WEBSITE = "http://www.antergos.com"
 CNCHI_RELEASE_STAGE = "production"
 

--- a/cnchi/installation/ask.py
+++ b/cnchi/installation/ask.py
@@ -92,7 +92,7 @@ def load_zfs():
 
 
 class InstallationAsk(GtkBaseBox):
-    def __init__(self, params, prev_page="features", next_page=None):
+    def __init__(self, params, prev_page="mirrors", next_page=None):
         super().__init__(self, params, "ask", prev_page, next_page)
 
         data_dir = self.settings.get("data")
@@ -102,8 +102,6 @@ class InstallationAsk(GtkBaseBox):
             "images",
             "partitioner",
             "small")
-
-        self.disable_rank_mirrors = params["disable_rank_mirrors"]
 
         image = self.ui.get_object("automatic_image")
         path = os.path.join(partitioner_dir, "automatic.png")
@@ -471,7 +469,7 @@ class InstallationAsk(GtkBaseBox):
                 must_wait = True
                 break
 
-        if not must_wait or self.disable_rank_mirrors:
+        if not must_wait:
             return
 
         txt1 = _("Ranking mirrors")

--- a/cnchi/language.py
+++ b/cnchi/language.py
@@ -38,8 +38,6 @@ from gtkbasebox import GtkBaseBox
 
 import misc.i18n as i18n
 
-from rank_mirrors import AutoRankmirrorsProcess
-
 # Useful vars for gettext (translations)
 APP_NAME = "cnchi"
 LOCALE_DIR = "/usr/share/locale"
@@ -68,10 +66,6 @@ class Language(GtkBaseBox):
 
         label = self.ui.get_object("welcome_label")
         label.set_name("WelcomeMessage")
-
-        # Boolean variable to check if rank_mirrors has already been run
-        self.rank_mirrors_launched = False
-        self.disable_rank_mirrors = params['disable_rank_mirrors']
 
         self.main_window = params['main_window']
 
@@ -213,18 +207,6 @@ class Language(GtkBaseBox):
         # a11y
         self.listbox.set_can_default(True)
         self.main_window.set_default(self.listbox)
-
-        # Launch rank mirrors process to optimize Arch and Antergos mirrorlists
-        if (not self.disable_rank_mirrors and
-                not self.rank_mirrors_launched):
-            proc = AutoRankmirrorsProcess(self.settings)
-            proc.daemon = True
-            proc.name = "rankmirrors"
-            proc.start()
-            self.process_list.append(proc)
-            self.rank_mirrors_launched = True
-        else:
-            logging.debug("Not running rank mirrors. This is discouraged.")
 
 # When testing, no _() is available
 try:

--- a/cnchi/location.py
+++ b/cnchi/location.py
@@ -49,7 +49,7 @@ from logging_utils import ContextFilter
 
 
 class Location(GtkBaseBox):
-    def __init__(self, params, prev_page="check", next_page="mirrors"):
+    def __init__(self, params, prev_page="check", next_page="timezone"):
         super().__init__(self, params, "location", prev_page, next_page)
 
         self.listbox = self.ui.get_object("listbox")

--- a/cnchi/location.py
+++ b/cnchi/location.py
@@ -49,7 +49,7 @@ from logging_utils import ContextFilter
 
 
 class Location(GtkBaseBox):
-    def __init__(self, params, prev_page="check", next_page="timezone"):
+    def __init__(self, params, prev_page="check", next_page="mirrors"):
         super().__init__(self, params, "location", prev_page, next_page)
 
         self.listbox = self.ui.get_object("listbox")

--- a/cnchi/location.py
+++ b/cnchi/location.py
@@ -52,7 +52,8 @@ class Location(GtkBaseBox):
     def __init__(self, params, prev_page="check", next_page="timezone"):
         super().__init__(self, params, "location", prev_page, next_page)
 
-        self.listbox = self.ui.get_object("listbox")
+        self.listbox = self.ui.get_object("location-listbox")
+        self.listbox.set_name("location-listbox")
         self.listbox.connect("row-selected", self.on_listbox_row_selected)
         self.listbox.set_selection_mode(Gtk.SelectionMode.BROWSE)
 

--- a/cnchi/main_window.py
+++ b/cnchi/main_window.py
@@ -223,7 +223,6 @@ class MainWindow(Gtk.ApplicationWindow):
 
         self.params['checks_are_optional'] = cmd_line.no_check
         self.params['disable_tryit'] = cmd_line.disable_tryit
-        self.params['disable_rank_mirrors'] = cmd_line.disable_rank_mirrors
         self.params['a11y'] = cmd_line.a11y
 
         # Just load the first two screens (the other ones will be loaded later)

--- a/cnchi/main_window.py
+++ b/cnchi/main_window.py
@@ -47,7 +47,7 @@ import user_info
 import slides
 import summary
 import info
-#import mirrors
+import mirrors
 
 import gi
 gi.require_version('Gtk', '3.0')
@@ -327,9 +327,10 @@ class MainWindow(Gtk.ApplicationWindow):
 
         self.pages["check"] = check.Check(self.params)
         self.pages["location"] = location.Location(self.params)
-        self.pages["timezone"] = timezone.Timezone(self.params)
 
-        #self.pages["mirrors"] = mirrors.Mirrors(self.params)
+        self.pages["mirrors"] = mirrors.Mirrors(self.params)
+
+        self.pages["timezone"] = timezone.Timezone(self.params)
 
         if self.settings.get('desktop_ask'):
             self.pages["keymap"] = keymap.Keymap(self.params)

--- a/cnchi/mirrors.py
+++ b/cnchi/mirrors.py
@@ -223,6 +223,9 @@ class MirrorListBox(Gtk.ListBox):
         surface.set_device_offset(-x, -y)
         Gtk.drag_set_icon_surface(drag_context, surface)
 
+        hand_cursor = Gdk.Cursor(Gdk.CursorType.HAND1)
+        self.get_window().set_cursor(hand_cursor)
+
     def on_drag_data_get(self, widget, drag_context, selection_data, info, time):
         """ When drag data is requested by the destination """
         row = widget.get_ancestor(Gtk.ListBoxRow)
@@ -230,6 +233,7 @@ class MirrorListBox(Gtk.ListBox):
         row_index = row.get_index()
         data = "{0}|{1}".format(listbox_str, row_index)
         selection_data.set_text(data, len(data))
+        self.get_window().set_cursor(None)
 
     def on_drag_data_received(self, widget, drag_context, x, y, selection_data, info, time):
         """ When drag data is received by the destination """

--- a/cnchi/mirrors.py
+++ b/cnchi/mirrors.py
@@ -245,7 +245,6 @@ class MirrorListBox(Gtk.ListBox):
         try:
             listbox_str = data.split('|')[0]
             if listbox_str == str(self):
-                row_index = widget.get_index()
                 old_index = int(data.split('|')[1])
                 new_index = widget.get_index()
                 self.mirrors.insert(new_index, self.mirrors.pop(old_index))
@@ -279,8 +278,6 @@ class MirrorListBox(Gtk.ListBox):
 class Mirrors(GtkBaseBox):
     def __init__(self, params, prev_page="features", next_page="installation_ask"):
         super().__init__(self, params, "mirrors", prev_page, next_page)
-
-        data_dir = self.settings.get("data")
 
         # Set up lists
         self.listboxes = []

--- a/cnchi/mirrors.py
+++ b/cnchi/mirrors.py
@@ -106,7 +106,7 @@ class MirrorListBoxRow(Gtk.ListBoxRow):
         # Destination
         self.drag_dest_set(Gtk.DestDefaults.ALL, [], Gdk.DragAction.MOVE)
         self.drag_dest_add_text_targets()
-        self.connect("drag-data-received", drag_cbs['drag-data-received']);
+        self.connect("drag-data-received", drag_cbs['drag-data-received'])
         #self.connect("drag-motion", self.on_drag_motion);
         #self.connect("drag-crop", self.on_drag_crop);
 
@@ -250,7 +250,7 @@ class MirrorListBox(Gtk.ListBox):
                 self.mirrors.insert(new_index, self.mirrors.pop(old_index))
                 self.fillme()
         except (KeyError, ValueError) as err:
-            pass
+            logging.warning(err)
 
 
     def save_changes(self):

--- a/cnchi/mirrors.py
+++ b/cnchi/mirrors.py
@@ -183,11 +183,7 @@ class MirrorListBox(Gtk.ListBox):
         for (url, active) in self.mirrors:
             box = Gtk.Box(spacing=20)
             box.set_name(url)
-            row = MirrorListBoxRow(
-                url,
-                active,
-                self.on_switch_activated,
-                drag_cbs)
+            row = MirrorListBoxRow(url, active, self.on_switch_activated, drag_cbs)
             self.add(row)
 
     def set_mirror_active(self, url, active):
@@ -222,7 +218,7 @@ class MirrorListBox(Gtk.ListBox):
         row.draw(ctx)
         row.get_style_context().remove_class("drag-icon")
 
-        (x, y) = widget.translate_coordinates (row, 0, 0)
+        (x, y) = widget.translate_coordinates(row, 0, 0)
 
         surface.set_device_offset(-x, -y)
         Gtk.drag_set_icon_surface(drag_context, surface)
@@ -248,7 +244,6 @@ class MirrorListBox(Gtk.ListBox):
                 self.show_all()
         except (KeyError, ValueError) as err:
             logging.warning(err)
-
 
     def save_changes(self):
         """ Save mirrors in mirrors list file """
@@ -307,6 +302,7 @@ class Mirrors(GtkBaseBox):
         self.check_active_mirrors()
 
     def check_active_mirrors(self):
+        """ Checks if at least there is one mirror active for each list """
         ok = True
         for listbox in self.listboxes:
             if len(listbox.get_active_mirrors()) == 0:

--- a/cnchi/mirrors.py
+++ b/cnchi/mirrors.py
@@ -304,6 +304,9 @@ class Mirrors(GtkBaseBox):
     def on_switch_activated(self, widget):
         """ A mirror has been activated/deactivated. We must check if
         at least there is one mirror active for each list """
+        self.check_active_mirrors()
+
+    def check_active_mirrors(self):
         ok = True
         for listbox in self.listboxes:
             if len(listbox.get_active_mirrors()) == 0:
@@ -313,17 +316,20 @@ class Mirrors(GtkBaseBox):
     def on_rank_radiobutton_toggled(self, widget):
         self.use_rankmirrors = True
         self.use_listboxes = False
+        self.forward_button.set_sensitive(True)
         self.listboxes_box.hide()
 
     def on_leave_radiobutton_toggled(self, widget):
         self.use_rankmirrors = False
         self.use_listboxes = False
+        self.forward_button.set_sensitive(True)
         self.listboxes_box.hide()
 
     def on_user_radiobutton_toggled(self, widget):
         self.use_rankmirrors = False
         self.use_listboxes = True
         self.show_all()
+        self.check_active_mirrors()
 
     def start_rank_mirrors(self):
         # Launch rank mirrors process to optimize Arch and Antergos mirrorlists

--- a/cnchi/mirrors.py
+++ b/cnchi/mirrors.py
@@ -277,11 +277,10 @@ class MirrorListBox(Gtk.ListBox):
 
 
 class Mirrors(GtkBaseBox):
-    def __init__(self, params, prev_page="location", next_page="timezone"):
+    def __init__(self, params, prev_page="features", next_page="installation_ask"):
         super().__init__(self, params, "mirrors", prev_page, next_page)
 
         data_dir = self.settings.get("data")
-        self.disable_rank_mirrors = params["disable_rank_mirrors"]
 
         # Set up lists
         self.listboxes = []
@@ -303,7 +302,6 @@ class Mirrors(GtkBaseBox):
 
         # Boolean variable to check if rank_mirrors has already been run
         self.rank_mirrors_launched = False
-        self.disable_rank_mirrors = params['disable_rank_mirrors']
 
     def on_switch_activated(self, widget):
         """ A mirror has been activated/deactivated. We must check if
@@ -335,15 +333,16 @@ class Mirrors(GtkBaseBox):
 
     def start_rank_mirrors(self):
         # Launch rank mirrors process to optimize Arch and Antergos mirrorlists
-        if (not self.disable_rank_mirrors and not self.rank_mirrors_launched):
+        # As user can come and go from/to this screen, we must get sure he/she
+        # has not already run the AutoRankmirrorsProcess before
+        if not self.rank_mirrors_launched:
+            logging.debug("Cnchi is ranking your mirrors lists...")
             proc = AutoRankmirrorsProcess(self.settings)
             proc.daemon = True
             proc.name = "rankmirrors"
             proc.start()
             self.process_list.append(proc)
             self.rank_mirrors_launched = True
-        else:
-            logging.debug("Not running rank mirrors. This is discouraged.")
 
     def prepare(self, direction):
         """ Prepares screen """

--- a/cnchi/test_screen.py
+++ b/cnchi/test_screen.py
@@ -140,7 +140,6 @@ def run(screen_name):
         'main_progressbar': Gtk.ProgressBar.new(),
         'header': Gtk.HeaderBar.new(),
         'callback_queue': None,
-        'disable_rank_mirrors': False,
         'alternate_package_list': "",
         'process_list': []}
 

--- a/cnchi/timezone.py
+++ b/cnchi/timezone.py
@@ -48,7 +48,7 @@ NM_STATE_CONNECTED_GLOBAL = 70
 
 class Timezone(GtkBaseBox):
     """ Timezone screen """
-    def __init__(self, params, prev_page="mirrors", next_page="keymap"):
+    def __init__(self, params, prev_page="location", next_page="keymap"):
         super().__init__(self, params, "timezone", prev_page, next_page)
 
         self.map_window = self.ui.get_object('timezone_map_window')

--- a/cnchi/timezone.py
+++ b/cnchi/timezone.py
@@ -48,7 +48,7 @@ NM_STATE_CONNECTED_GLOBAL = 70
 
 class Timezone(GtkBaseBox):
     """ Timezone screen """
-    def __init__(self, params, prev_page="location", next_page="keymap"):
+    def __init__(self, params, prev_page="mirrors", next_page="keymap"):
         super().__init__(self, params, "timezone", prev_page, next_page)
 
         self.map_window = self.ui.get_object('timezone_map_window')

--- a/data/css/gtk-style.css
+++ b/data/css/gtk-style.css
@@ -239,9 +239,9 @@ StateBox {
 }
 
 #location-listbox, .row .label {
-    font-size: 14px;
+    font-size: 12px;
 }
 
 #location-listbox, .row .label:hover {
-    font-size: 14px;
+    font-size: 12px;
 }

--- a/data/css/gtk-style.css
+++ b/data/css/gtk-style.css
@@ -3,7 +3,6 @@
     font-size: 11px;
 }
 
-
 #location {
     font-size: 11px;
 }
@@ -26,9 +25,7 @@ window {
     text-shadow: 0px 1px 0px #222;
 }
 
-.label.subtitle,
-#header .subtitle,
-.subtitle {
+.label.subtitle, #header .subtitle, .subtitle {
     font-size: 13px;
     font-weight: 400;
     font-family: 'Open Sans';
@@ -140,8 +137,7 @@ headerbar separator {
     color: rgba(255, 255, 255, 0.08);
 }
 
-toolbar separator, separator,
-headerbar separator {
+toolbar separator, separator, headerbar separator {
     margin-left: 10px;
 }
 
@@ -240,4 +236,12 @@ GtkTreeView row:selected {
 
 StateBox {
     border-radius: 2px;
+}
+
+#location-listbox, .row .label {
+    font-size: 14px;
+}
+
+#location-listbox, .row .label:hover {
+    font-size: 14px;
 }

--- a/data/packages.xml
+++ b/data/packages.xml
@@ -546,37 +546,11 @@
                <pkgname>antergos-wallpapers-deepin</pkgname>
                <pkgname>adwaita-icon-theme</pkgname>
                <pkgname>brasero</pkgname>
-               <pkgname>deepin-account-faces</pkgname>
-               <pkgname>deepin-api</pkgname>
-               <pkgname>deepin-artwork-themes</pkgname>
-               <pkgname>deepin-calendar</pkgname>
+               <pkgname>deepin</pkgname>
+               <pkgname>deepin-extra</pkgname>
                <pkgname>deepin-cogl</pkgname>
-               <pkgname>deepin-control-center</pkgname>
-               <pkgname>deepin-daemon</pkgname>
-               <pkgname>deepin-desktop-base</pkgname>
-               <pkgname>deepin-desktop-schemas</pkgname>
-               <pkgname>deepin-dock</pkgname>
-               <pkgname>deepin-file-manager</pkgname>
-               <pkgname>deepin-grub2-themes</pkgname>
-               <pkgname>deepin-gtk-theme</pkgname>
-               <pkgname>deepin-image-viewer</pkgname>
-               <pkgname>deepin-launcher</pkgname>
-               <pkgname>deepin-menu</pkgname>
-               <pkgname>deepin-movie</pkgname>
-               <pkgname>deepin-music</pkgname>
                <pkgname>deepin-mutter</pkgname>
-               <pkgname>deepin-notifications</pkgname>
-               <pkgname>deepin-qt5integration</pkgname>
-               <pkgname>deepin-screenshot</pkgname>
-               <pkgname>deepin-screen-recorder</pkgname>
-               <pkgname>deepin-session-ui</pkgname>
-               <pkgname>deepin-shortcut-viewer</pkgname>
-               <pkgname>deepin-sound-theme</pkgname>
-               <pkgname>deepin-system-monitor</pkgname>
-               <pkgname>deepin-terminal</pkgname>
-               <pkgname>deepin-voice-recorder</pkgname>
-               <pkgname>deepin-wallpapers</pkgname>
-               <pkgname>deepin-wm-switcher</pkgname>
+               <pkgname>deepin-polkit-agent</pkgname>
                <pkgname>dtkwm</pkgname>
                <pkgname>gedit</pkgname>
                <pkgname>gnome-calculator</pkgname>
@@ -591,7 +565,6 @@
                <pkgname>noto-fonts-cjk</pkgname>
                <pkgname>noto-fonts-emoji</pkgname>
                <pkgname>pamac</pkgname>
-               <pkgname>startdde</pkgname>
                <pkgname>unicode-character-database</pkgname>
            </packages>
        </edition>

--- a/data/packages.xml
+++ b/data/packages.xml
@@ -26,6 +26,7 @@
                 <pkgname>ntfs-3g</pkgname>
                 <pkgname>openssh</pkgname>
                 <pkgname>pkgfile</pkgname>
+                <pkgname>reflector</pkgname>
                 <pkgname>sudo</pkgname>
                 <pkgname>terminus-font</pkgname>
                 <pkgname>tlp</pkgname>
@@ -580,8 +581,12 @@
                <pkgname>gedit</pkgname>
                <pkgname>gnome-calculator</pkgname>
                <pkgname>gnome-disk-utility</pkgname>
+               <pkgname>gnome-font-viewer</pkgname>
                <pkgname>gnome-software</pkgname>
+               <pkgname>gtk-theme-paper</pkgname>
+               <pkgname>gtk-theme-adapta</pkgname>
                <pkgname nm='true' name='NetworkManager'>network-manager-applet</pkgname>
+               <pkgname>network-manager-openvpn</pkgname>
                <pkgname>noto-fonts</pkgname>
                <pkgname>noto-fonts-cjk</pkgname>
                <pkgname>noto-fonts-emoji</pkgname>

--- a/data/packages.xml
+++ b/data/packages.xml
@@ -586,7 +586,7 @@
                <pkgname>gtk-theme-paper</pkgname>
                <pkgname>gtk-theme-adapta</pkgname>
                <pkgname nm='true' name='NetworkManager'>network-manager-applet</pkgname>
-               <pkgname>network-manager-openvpn</pkgname>
+               <pkgname>networkmanager-openvpn</pkgname>
                <pkgname>noto-fonts</pkgname>
                <pkgname>noto-fonts-cjk</pkgname>
                <pkgname>noto-fonts-emoji</pkgname>

--- a/run
+++ b/run
@@ -32,7 +32,8 @@ if [ -f /usr/bin/python3 ]; then
 fi
 
 #sudo -E $_PYTHON $_PYTHON_OPTIONS cnchi/cnchi.py $_CNCHI_OPTIONS -p $_XML ${@} 2>&1
-pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY $CNCHI_DIR/bin/cnchi $_CNCHI_OPTIONS -p $_XML ${@} 2>&1
+
+pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY GTK_DEBUG=interactive $CNCHI_DIR/bin/cnchi $_CNCHI_OPTIONS -p $_XML ${@} 2>&1
 
 exit 0
 

--- a/run
+++ b/run
@@ -25,7 +25,7 @@ sudo ln -sf $CNCHI_DIR /usr/share/cnchi
 _PYTHON="/usr/bin/python"
 _PYTHON_OPTIONS="-Wall"
 _XML="/usr/share/cnchi/data/packages.xml"
-_CNCHI_OPTIONS="-d -v --disable-rank-mirrors -s bugsnag"
+_CNCHI_OPTIONS="-d -v -s bugsnag"
 
 if [ -f /usr/bin/python3 ]; then
     _PYTHON="/usr/bin/python3"

--- a/ui/location.ui
+++ b/ui/location.ui
@@ -52,7 +52,7 @@
             <property name="shadow_type">in</property>
             <property name="hexpand">true</property>
             <child>
-              <object class="GtkListBox" id="listbox">
+              <object class="GtkListBox" id="location-listbox">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
               </object>

--- a/ui/mirrors.ui
+++ b/ui/mirrors.ui
@@ -2,189 +2,187 @@
 <interface>
 <requires lib="gtk+" version="3.18"/>
 <object class="GtkBox" id="mirrors">
-  <property name="visible">True</property>
-  <property name="can_focus">False</property>
-  <!--<property name="halign">fill</property>-->
-  <property name="halign">center</property>
-  <property name="margin_bottom">10</property>
-  <property name="margin_top">0</property>
-  <property name="margin_start">10</property>
-  <property name="margin_end">10</property>
-  <!--<property name="hexpand">True</property>-->
-  <property name="orientation">vertical</property>
-  <child>
-    <object class="GtkLabel" id="introduction">
-      <property name="visible">True</property>
-      <property name="can_focus">False</property>
-      <property name="margin_top">10</property>
-      <property name="margin_bottom">8</property>
-      <property name="halign">center</property>
-      <property name="valign">start</property>
-      <property name="label" translatable="yes"></property>
-      <property name="use_markup">True</property>
-      <property name="justify">fill</property>
-    </object>
-    <packing>
-      <property name="expand">False</property>
-      <property name="fill">False</property>
-      <property name="position">0</property>
-    </packing>
-  </child>
-  <child>
-    <object class="GtkBox" id="rank_box">
-      <property name="hexpand">True</property>
-      <property name="orientation">horizontal</property>
-      <property name="margin_top">10</property>
-      <child>
-        <object class="GtkRadioButton" id="rank_radiobutton">
-          <property name="label" translatable="yes"></property>
-          <property name="visible">True</property>
-          <property name="can_focus">True</property>
-          <property name="receives_default">False</property>
-          <property name="halign">start</property>
-          <property name="always_show_image">True</property>
-          <property name="active">True</property>
-          <property name="draw_indicator">True</property>-->
-          <signal name="toggled" handler="on_rank_radiobutton_toggled" swapped="no"/>
-        </object>
-        <packing>
-          <property name="expand">False</property>
-          <property name="fill">True</property>
-          <property name="position">1</property>
-        </packing>
-      </child>
-    </object>
-    <packing>
-      <property name="expand">False</property>
-      <property name="fill">True</property>
-      <property name="position">1</property>
-    </packing>
-  </child>
-  <!-- end of rank mirrors -->
-  <!-- Leave mirror list as it is -->
-  <child>
-    <object class="GtkBox" id="leave_box">
-      <property name="hexpand">True</property>
-      <property name="orientation">horizontal</property>
-      <property name="margin_top">10</property>
-      <child>
-        <object class="GtkRadioButton" id="leave_radiobutton">
-          <property name="label" translatable="yes"></property>
-          <property name="visible">True</property>
-          <property name="can_focus">True</property>
-          <property name="receives_default">False</property>
-          <property name="halign">start</property>
-          <property name="always_show_image">True</property>
-          <property name="active">True</property>
-          <property name="draw_indicator">True</property>
-          <property name="group">rank_radiobutton</property>
-          <signal name="toggled" handler="on_leave_radiobutton_toggled" swapped="no"/>
-        </object>
-        <packing>
-          <property name="expand">False</property>
-          <property name="fill">True</property>
-          <property name="position">1</property>
-        </packing>
-      </child>
-    </object>
-    <packing>
-      <property name="expand">False</property>
-      <property name="fill">True</property>
-      <property name="position">2</property>
-    </packing>
-  </child>
-  <!-- end of leave mirror list as it is -->
-  <!-- Let user select mirrors -->
-  <child>
-    <object class="GtkBox" id="user_box">
-      <property name="hexpand">True</property>
-      <property name="orientation">horizontal</property>
-      <property name="margin_top">10</property>
-      <child>
-        <object class="GtkRadioButton" id="user_radiobutton">
-          <property name="label" translatable="yes"></property>
-          <property name="visible">True</property>
-          <property name="can_focus">True</property>
-          <property name="receives_default">False</property>
-          <property name="halign">start</property>
-          <property name="always_show_image">True</property>
-          <property name="active">True</property>
-          <property name="draw_indicator">True</property>
-          <property name="group">rank_radiobutton</property>
-          <signal name="toggled" handler="on_user_radiobutton_toggled" swapped="no"/>
-        </object>
-        <packing>
-          <property name="expand">False</property>
-          <property name="fill">True</property>
-          <property name="position">1</property>
-        </packing>
-      </child>
-    </object>
-    <packing>
-      <property name="expand">False</property>
-      <property name="fill">True</property>
-      <property name="position">3</property>
-    </packing>
-  </child>
-  <!-- mirror list listbox -->
-  <child>
-      <object class="GtkBox" id="listboxes_box">
-        <property name="hexpand">True</property>
-        <property name="orientation">horizontal</property>
-        <property name="margin_top">10</property>
-        <child>
-            <object class="GtkScrolledWindow" id="scrolledwindow1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="halign">center</property>
+    <property name="margin_bottom">10</property>
+    <property name="margin_top">0</property>
+    <property name="margin_start">10</property>
+    <property name="margin_end">10</property>
+    <property name="orientation">vertical</property>
+    <child>
+        <object class="GtkLabel" id="introduction">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
-            <property name="hscrollbar_policy">never</property>
-            <property name="shadow_type">in</property>
-            <property name="margin_right">5</property>
-                <!--<child>
-                    <object class="GtkListBox" id="arch_mirrors_listbox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                    </object>
-                </child>-->
-            </object>
-            <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-            </packing>
-      </child>
-
-      <child>
-        <object class="GtkScrolledWindow" id="scrolledwindow2">
-          <property name="visible">True</property>
-          <property name="can_focus">True</property>
-          <property name="hexpand">True</property>
-          <property name="vexpand">True</property>
-          <property name="hscrollbar_policy">never</property>
-          <property name="shadow_type">in</property>
-          <property name="margin_left">5</property>
-          <!--<child>
-            <object class="GtkListBox" id="antergos_mirrors_listbox">
-              <property name="visible">True</property>
-              <property name="can_focus">True</property>
-            </object>
-          </child>-->
+            <property name="can_focus">False</property>
+            <property name="margin_top">10</property>
+            <property name="margin_bottom">8</property>
+            <property name="halign">center</property>
+            <property name="valign">start</property>
+            <property name="label" translatable="yes"></property>
+            <property name="use_markup">True</property>
+            <property name="justify">fill</property>
         </object>
         <packing>
-          <property name="expand">True</property>
-          <property name="fill">True</property>
-          <property name="position">1</property>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
         </packing>
-      </child>
-    </object>
-    <packing>
-      <property name="expand">True</property>
-      <property name="fill">True</property>
-      <property name="position">4</property>
-    </packing>
-</child>
-
-
+    </child>
+    <child>
+        <object class="GtkBox" id="rank_box">
+            <property name="hexpand">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="margin_top">10</property>
+            <property name="margin_left">190</property>
+            <child>
+                <object class="GtkRadioButton" id="rank_radiobutton">
+                    <property name="label" translatable="yes"></property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="always_show_image">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>-->
+                    <signal name="toggled" handler="on_rank_radiobutton_toggled" swapped="no"/>
+                </object>
+                <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                </packing>
+            </child>
+        </object>
+        <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+        </packing>
+    </child>
+    <!-- end of rank mirrors -->
+    <!-- Leave mirror list as it is -->
+    <child>
+        <object class="GtkBox" id="leave_box">
+            <property name="hexpand">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="margin_top">10</property>
+            <property name="margin_left">190</property>
+            <child>
+                <object class="GtkRadioButton" id="leave_radiobutton">
+                    <property name="label" translatable="yes"></property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="always_show_image">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">rank_radiobutton</property>
+                    <signal name="toggled" handler="on_leave_radiobutton_toggled" swapped="no"/>
+                </object>
+                <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                </packing>
+            </child>
+        </object>
+        <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+        </packing>
+    </child>
+    <!-- end of leave mirror list as it is -->
+    <!-- Let user select mirrors -->
+    <child>
+        <object class="GtkBox" id="user_box">
+            <property name="hexpand">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="margin_top">10</property>
+            <property name="margin_left">190</property>
+            <child>
+                <object class="GtkRadioButton" id="user_radiobutton">
+                    <property name="label" translatable="yes"></property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="halign">start</property>
+                    <property name="always_show_image">True</property>
+                    <property name="active">True</property>
+                    <property name="draw_indicator">True</property>
+                    <property name="group">rank_radiobutton</property>
+                    <signal name="toggled" handler="on_user_radiobutton_toggled" swapped="no"/>
+                </object>
+                <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                </packing>
+            </child>
+        </object>
+        <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+        </packing>
+    </child>
+    <!-- mirror list listboxes -->
+    <child>
+        <object class="GtkBox" id="listboxes_box">
+            <property name="hexpand">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="margin_top">10</property>
+            <child>
+                <object class="GtkScrolledWindow" id="scrolledwindow1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="hscrollbar_policy">never</property>
+                    <property name="shadow_type">in</property>
+                    <property name="margin_right">5</property>
+                    <!--<child>
+                    <object class="GtkListBox" id="arch_mirrors_listbox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    </object>
+                    </child>-->
+                </object>
+                <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                </packing>
+            </child>
+            <child>
+                <object class="GtkScrolledWindow" id="scrolledwindow2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="hscrollbar_policy">never</property>
+                    <property name="shadow_type">in</property>
+                    <property name="margin_left">5</property>
+                    <!--<child>
+                    <object class="GtkListBox" id="antergos_mirrors_listbox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    </object>
+                    </child>-->
+                </object>
+                <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                </packing>
+            </child>
+        </object>
+        <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+        </packing>
+    </child>
 </object>
 </interface>

--- a/ui/mirrors.ui
+++ b/ui/mirrors.ui
@@ -34,7 +34,7 @@
     <object class="GtkBox" id="rank_box">
       <property name="hexpand">True</property>
       <property name="orientation">horizontal</property>
-      <property name="margin_top">5</property>
+      <property name="margin_top">10</property>
       <child>
         <object class="GtkRadioButton" id="rank_radiobutton">
           <property name="label" translatable="yes"></property>
@@ -66,7 +66,7 @@
     <object class="GtkBox" id="leave_box">
       <property name="hexpand">True</property>
       <property name="orientation">horizontal</property>
-      <property name="margin_top">5</property>
+      <property name="margin_top">10</property>
       <child>
         <object class="GtkRadioButton" id="leave_radiobutton">
           <property name="label" translatable="yes"></property>
@@ -90,7 +90,7 @@
     <packing>
       <property name="expand">False</property>
       <property name="fill">True</property>
-      <property name="position">11</property>
+      <property name="position">2</property>
     </packing>
   </child>
   <!-- end of leave mirror list as it is -->
@@ -123,31 +123,68 @@
     <packing>
       <property name="expand">False</property>
       <property name="fill">True</property>
-      <property name="position">13</property>
+      <property name="position">3</property>
     </packing>
   </child>
   <!-- mirror list listbox -->
   <child>
-    <object class="GtkScrolledWindow" id="scrolledwindow">
-      <property name="visible">True</property>
-      <property name="can_focus">True</property>
-      <property name="hexpand">True</property>
-      <property name="vexpand">True</property>
-      <property name="hscrollbar_policy">never</property>
-      <property name="shadow_type">in</property>
+      <object class="GtkBox" id="listboxes_box">
+        <property name="hexpand">True</property>
+        <property name="orientation">horizontal</property>
+        <property name="margin_top">10</property>
+        <child>
+            <object class="GtkScrolledWindow" id="scrolledwindow1">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="hscrollbar_policy">never</property>
+            <property name="shadow_type">in</property>
+            <property name="margin_right">5</property>
+                <child>
+                    <object class="GtkListBox" id="arch_mirrors_listbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                    </object>
+                </child>
+            </object>
+            <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+            </packing>
+      </child>
+
       <child>
-        <object class="GtkListBox" id="mirrors_listbox">
+        <object class="GtkScrolledWindow" id="scrolledwindow2">
           <property name="visible">True</property>
           <property name="can_focus">True</property>
+          <property name="hexpand">True</property>
+          <property name="vexpand">True</property>
+          <property name="hscrollbar_policy">never</property>
+          <property name="shadow_type">in</property>
+          <property name="margin_left">5</property>
+          <child>
+            <object class="GtkListBox" id="antergos_mirrors_listbox">
+              <property name="visible">True</property>
+              <property name="can_focus">True</property>
+            </object>
+          </child>
         </object>
+        <packing>
+          <property name="expand">True</property>
+          <property name="fill">True</property>
+          <property name="position">1</property>
+        </packing>
       </child>
     </object>
     <packing>
       <property name="expand">True</property>
       <property name="fill">True</property>
-      <property name="position">0</property>
+      <property name="position">4</property>
     </packing>
-  </child>
-  <!-- end of let user manage mirror list -->
+</child>
+
+
 </object>
 </interface>

--- a/ui/mirrors.ui
+++ b/ui/mirrors.ui
@@ -5,6 +5,7 @@
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="halign">center</property>
+    <property name="hexpand">True</property>
     <property name="margin_bottom">10</property>
     <property name="margin_top">0</property>
     <property name="margin_start">10</property>
@@ -28,105 +29,84 @@
             <property name="position">0</property>
         </packing>
     </child>
+    <!-- options -->
     <child>
-        <object class="GtkBox" id="rank_box">
-            <property name="hexpand">True</property>
+        <object class="GtkBox" id="center_box">
             <property name="orientation">horizontal</property>
-            <property name="margin_top">10</property>
-            <property name="margin_left">190</property>
+            <property name="halign">center</property>
             <child>
-                <object class="GtkRadioButton" id="rank_radiobutton">
-                    <property name="label" translatable="yes"></property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="halign">start</property>
-                    <property name="always_show_image">True</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>-->
-                    <signal name="toggled" handler="on_rank_radiobutton_toggled" swapped="no"/>
+                <object class="GtkBox" id="rank_box">
+                    <property name="orientation">vertical</property>
+                    <property name="margin_top">10</property>
+                    <child>
+                        <object class="GtkRadioButton" id="rank_radiobutton">
+                            <property name="label" translatable="yes"></property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>-->
+                            <signal name="toggled" handler="on_rank_radiobutton_toggled" swapped="no"/>
+                        </object>
+                        <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                        </packing>
+                    </child>
+                    <child>
+                        <object class="GtkRadioButton" id="leave_radiobutton">
+                            <property name="label" translatable="yes"></property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">rank_radiobutton</property>
+                            <signal name="toggled" handler="on_leave_radiobutton_toggled" swapped="no"/>
+                        </object>
+                        <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                        </packing>
+                    </child>
+                    <child>
+                        <object class="GtkRadioButton" id="user_radiobutton">
+                            <property name="label" translatable="yes"></property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">rank_radiobutton</property>
+                            <signal name="toggled" handler="on_user_radiobutton_toggled" swapped="no"/>
+                        </object>
+                        <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                        </packing>
+                    </child>
                 </object>
                 <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">0</property>
                 </packing>
             </child>
         </object>
         <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
+            <!--<property name="position">1</property>-->
             <property name="position">1</property>
         </packing>
     </child>
-    <!-- end of rank mirrors -->
-    <!-- Leave mirror list as it is -->
-    <child>
-        <object class="GtkBox" id="leave_box">
-            <property name="hexpand">True</property>
-            <property name="orientation">horizontal</property>
-            <property name="margin_top">10</property>
-            <property name="margin_left">190</property>
-            <child>
-                <object class="GtkRadioButton" id="leave_radiobutton">
-                    <property name="label" translatable="yes"></property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="halign">start</property>
-                    <property name="always_show_image">True</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
-                    <property name="group">rank_radiobutton</property>
-                    <signal name="toggled" handler="on_leave_radiobutton_toggled" swapped="no"/>
-                </object>
-                <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                </packing>
-            </child>
-        </object>
-        <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-        </packing>
-    </child>
-    <!-- end of leave mirror list as it is -->
-    <!-- Let user select mirrors -->
-    <child>
-        <object class="GtkBox" id="user_box">
-            <property name="hexpand">True</property>
-            <property name="orientation">horizontal</property>
-            <property name="margin_top">10</property>
-            <property name="margin_left">190</property>
-            <child>
-                <object class="GtkRadioButton" id="user_radiobutton">
-                    <property name="label" translatable="yes"></property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="halign">start</property>
-                    <property name="always_show_image">True</property>
-                    <property name="active">True</property>
-                    <property name="draw_indicator">True</property>
-                    <property name="group">rank_radiobutton</property>
-                    <signal name="toggled" handler="on_user_radiobutton_toggled" swapped="no"/>
-                </object>
-                <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                </packing>
-            </child>
-        </object>
-        <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-        </packing>
-    </child>
+
     <!-- mirror list listboxes -->
     <child>
         <object class="GtkBox" id="listboxes_box">
@@ -181,7 +161,7 @@
         <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">2</property>
         </packing>
     </child>
 </object>

--- a/ui/mirrors.ui
+++ b/ui/mirrors.ui
@@ -141,12 +141,12 @@
             <property name="hscrollbar_policy">never</property>
             <property name="shadow_type">in</property>
             <property name="margin_right">5</property>
-                <child>
+                <!--<child>
                     <object class="GtkListBox" id="arch_mirrors_listbox">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                     </object>
-                </child>
+                </child>-->
             </object>
             <packing>
                 <property name="expand">True</property>
@@ -164,12 +164,12 @@
           <property name="hscrollbar_policy">never</property>
           <property name="shadow_type">in</property>
           <property name="margin_left">5</property>
-          <child>
+          <!--<child>
             <object class="GtkListBox" id="antergos_mirrors_listbox">
               <property name="visible">True</property>
               <property name="can_focus">True</property>
             </object>
-          </child>
+          </child>-->
         </object>
         <packing>
           <property name="expand">True</property>

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.327","files":[
+{"version":"0.14.328","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.331","files":[
+{"version":"0.14.332","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.326","files":[
+{"version":"0.14.327","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.323","files":[
+{"version":"0.14.324","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.332","files":[
+{"version":"0.14.333","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.340","files":[
+{"version":"0.14.341","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.325","files":[
+{"version":"0.14.326","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.333","files":[
+{"version":"0.14.334","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.329","files":[
+{"version":"0.14.330","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.335","files":[
+{"version":"0.14.336","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.322","files":[
+{"version":"0.14.323","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.328","files":[
+{"version":"0.14.329","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.336","files":[
+{"version":"0.14.337","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.338","files":[
+{"version":"0.14.339","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.339","files":[
+{"version":"0.14.340","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.334","files":[
+{"version":"0.14.335","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.324","files":[
+{"version":"0.14.325","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.330","files":[
+{"version":"0.14.331","files":[
 ]}

--- a/update.info
+++ b/update.info
@@ -1,2 +1,2 @@
-{"version":"0.14.337","files":[
+{"version":"0.14.338","files":[
 ]}


### PR DESCRIPTION
![mirrors_screen](https://user-images.githubusercontent.com/175797/29851813-805f2e9a-8d36-11e7-872e-b8d2d73d3fb5.png)

@lots0logs @axaxs @faidoc 

I've created this new screen for cnchi that allows users to (with both mirrorlists):
- Run our rankmirrors process
- Do nothing
- Manually sort and activate/deactivate mirrors in both mirrorlists

I've tested and it works quite well. It only uses a maximum of 6 mirrors from each list, but this could be changed.

I know the design is ugly as hell. Geez, I'm a programmer, not a designer.

At lest you can sort list items by dragging them, which I think is pretty cool.

The screen shows up after the features one and before the install one (automatic or advanced). I'm also open to move it to another section ;)

I'd be grateful for any comments / criticisms...

Oh, if we do this we must remember to warn IRC and Forum moderators.

P.S. There is one problem, and that is that if user selects to run rankmirrors, and then goes back and sorts mirrors himself, then the rankmirrors process will overwrite user's changes when it finishes. Or, if user waits enough, he will be able to overwrite rankmirrors changes. Maybe once rankmirrors is selected and forward is pressed (and rankmirrors process launched), user should not be able to go back and select the option of manually sorting mirrorlists.... duh... It's so late that I can't think straight. As I said, I'm open for comments....


