### PR TITLE
Removes obsolete package libtxc_dxtn

### DIFF
--- a/src/hardware/modules/i915.py
+++ b/src/hardware/modules/i915.py
@@ -51,7 +51,7 @@ class Intel915(Hardware):
     @staticmethod
     def get_packages():
         """ Get all required packages """
-        pkgs = ["xf86-video-intel", "libva-intel-driver", "libtxc_dxtn"]
+        pkgs = ["xf86-video-intel", "libva-intel-driver"]
         if os.uname()[-1] == "x86_64":
             pkgs.extend(["lib32-mesa"])
         return pkgs

--- a/src/hardware/modules/radeon.py
+++ b/src/hardware/modules/radeon.py
@@ -55,7 +55,7 @@ class Radeon(Hardware):
     @staticmethod
     def get_packages():
         """ Get all required packages """
-        pkgs = ["xf86-video-ati", "libva-vdpau-driver", "libtxc_dxtn"]
+        pkgs = ["xf86-video-ati", "libva-vdpau-driver"]
         if os.uname()[-1] == "x86_64":
             pkgs.extend(["lib32-mesa"])
         return pkgs


### PR DESCRIPTION
Hi!

I was testing out the fix for #848 and I ran across a problem where the `libtxc_dxtn` was missing, which halted installation. A bit of research turned up that it was recently dropped from `extra` after its functionality was folded into Mesa. See:

  - https://lists.archlinux.org/pipermail/arch-dev-public/2018-January/029080.html
  - https://bugs.archlinux.org/task/56660?dev=53660
  - https://lists.freedesktop.org/archives/mesa-dev/2017-October/171265.html

This PR removes the requirement for the lib from the requirements for Intel and Radeon hardware.

Testing-wise, a fresh install worked on my Skull Canyon NUC; I was running against the `0.14.x` branch (hence the target of this PR), but a similar change seems warranted in `master`.

Many thanks!