### PR TITLE
Remove xorg-mkfontdir from packages.xml

### DIFF
--- a/data/packages.xml
+++ b/data/packages.xml
@@ -86,7 +86,6 @@
                 <pkgname>xorg-bdftopcf</pkgname>
                 <pkgname>xorg-iceauth</pkgname>
                 <pkgname>xorg-luit</pkgname>
-                <pkgname>xorg-mkfontdir</pkgname>
                 <pkgname>xorg-mkfontscale</pkgname>
                 <pkgname>xorg-sessreg</pkgname>
                 <pkgname>xorg-setxkbmap</pkgname>


### PR DESCRIPTION
xorg-mkfontdir is provided by xorg-mkfontscale according to https://www.archlinux.org/packages/extra/x86_64/xorg-mkfontscale/